### PR TITLE
fix: use environment file to manage outputs

### DIFF
--- a/docs/markdown/03-Interact-With-Env/01-Environment-Variables.md
+++ b/docs/markdown/03-Interact-With-Env/01-Environment-Variables.md
@@ -95,7 +95,7 @@ steps:
 ```yaml
 steps:
   - name: Set selected color
-    run: echo '::set-output name=SELECTED_COLOR::green'
+    run: echo 'SELECTED_COLOR=green' >> $GITHUB_OUTPUT
     id: random-color-generator
 
   - name: Get color
@@ -129,7 +129,7 @@ jobs:
     steps:
       - id: step1
         name: send url to other job
-        run: echo "::set-output name=url::https://google.com"
+        run: echo 'url=https://google.com' >> $GITHUB_OUTPUT
 ```
 
 <br>

--- a/docs/markdown/06-Advanced-Concepts/01-Advanced-concept.md
+++ b/docs/markdown/06-Advanced-Concepts/01-Advanced-concept.md
@@ -322,7 +322,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - id: set-matrix
-        run: echo "::set-output name=matrix::{\"include\":[{\"project\":\"foo\",\"config\":\"Debug\"},{\"project\":\"bar\",\"config\":\"Release\"}]}"
+        run: echo "matrix={\"include\":[{\"project\":\"foo\",\"config\":\"Debug\"},{\"project\":\"bar\",\"config\":\"Release\"}]}" >> $GITHUB_OUTPUT
   job2:
     needs: job1
     runs-on: ubuntu-latest

--- a/steps/03-Interact-With-Env-solution/ex3_interact_with_github_api.yml
+++ b/steps/03-Interact-With-Env-solution/ex3_interact_with_github_api.yml
@@ -11,9 +11,9 @@ jobs:
       - id: short_sha
         run: |
           GITHUB_PR_SHA=${{github.event.pull_request.base.sha}}
-           
-          echo "::set-output name=sha_short::${GITHUB_SHA::7}"
-          # echo "::set-output name=sha_short::${GITHUB_PR_SHA::7}"
+          
+          echo "sha_short=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+          # echo "sha_short=${GITHUB_PR_SHA::7}" >> $GITHUB_OUTPUT
       # - id: short_sha
       #   run: |
       #     echo "GITHUB_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV 


### PR DESCRIPTION
Since  `::set-output` is now deprecated